### PR TITLE
Introduce tabbing

### DIFF
--- a/docs/tab-example.html
+++ b/docs/tab-example.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Medium.js Example</title>
+    <meta charset='utf-8'> 
+    <link rel="stylesheet" type="text/css" href="../medium.css">
+    <link rel="stylesheet" type="text/css" href="prism.css">
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+    <script src="../medium.js"></script>
+    <script src="prism.js"></script>
+    <script type="text/javascript">
+      jQuery(document).ready(function() {
+
+        new Medium({
+            element: document.getElementById('article'),
+            mode: 'rich',
+            placeholder: 'Your Article'
+        });
+
+      });
+    </script>
+  </head>
+  <body>
+    <pre>
+      <div id="article" class="article demo" style='font-family:Verdana;'>foo</div>
+    </pre>
+  </body>
+</html>

--- a/medium.js
+++ b/medium.js
@@ -78,6 +78,11 @@
                     return fnFalse.call();
                 }
             },
+            isTab: function(e, fn){
+                if(e.which == 9){
+                    return fn.call();
+                }
+            },
             isShift: function(e, fnTrue, fnFalse){
                 if(e.shiftKey){
                     return fnTrue.call();
@@ -382,6 +387,9 @@
                 }, function(){
                     cache.shift = false;
                 });
+                utils.isTab(e, function(){
+                    intercept.command['tab'].call(null, e);
+                });
                 utils.isModifier(e, function(cmd){
                     if( cache.cmd ){
                         
@@ -421,6 +429,29 @@
                 action.preserveElementFocus();
             },
             command: {
+                tab: function(e){
+                    var sel = utils.selection.saveSelection();
+                    
+                    var original = utils.html.text(sel.startContainer);
+                    var position = sel.startOffset;
+                    if( !cache.shift ){
+                        var output = [original.slice(0, position), "\t", original.slice(position)].join('');
+
+                        utils.html.text(sel.startContainer, output);
+                        utils.cursor.set( position + 1, sel.startContainer );
+                        utils.preventDefaultEvent(e);
+                    } else {
+                        // if the previous character is a tab, untab
+                        if (original.slice(position-1, position) == '\t') {
+                            var output = [original.slice(0, position-1), original.slice(position)].join('');
+
+                            utils.html.text(sel.startContainer, output);
+                            utils.cursor.set( position - 1, sel.startContainer );
+                            // place the call here so if the previous char is not a tab the event bubbles up
+                            utils.preventDefaultEvent(e);
+                        }
+                    }
+                },
                 bold: function(e){
                     utils.preventDefaultEvent(e);
                     // IE uses strong instead of b


### PR DESCRIPTION
I think additional work is required here for sure, this could easily be buggy.

Also, since most people are not likely to be wrapping their contenteditable blocks with a `<pre>` tag it would make sense to perhaps give an option for using spaces instead of tabs, and specifying the character so that `&nbsp;` can be used?

I'm not HTML or JS expert so, please advise. If you don't want tabbing at all, I'll happily keep this in my branch. Thanks for Medium.js, your code is extremely readable.
