### PR TITLE
Added 'rel' attribute to stylesheet link in usage doc

### DIFF
--- a/docs/partials/usage.html
+++ b/docs/partials/usage.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <script src="medium.js"></script>
-        <link href="medium.css">
+        <link rel="stylesheet" href="medium.css">
     </head>
     <body>
     


### PR DESCRIPTION
This is vitally important - at least, it is in Chrome v29. Without it, the browser doesn't know to interpret that link as a stylesheet, and doesn't load the styles. And without those styles, Medium.js just doesn't work. Took me a lot of messing about to realise that; maybe I'm not the only one to copy the example from usage and assume that it works! ;-)
