### PR TITLE
Allow configuration of which attributes are removed during clean()

### DIFF
--- a/medium.js
+++ b/medium.js
@@ -51,6 +51,9 @@
                 editor: 'Medium',
                 pasteHook: 'Medium-paste-hook',
                 placeholder: 'Medium-placeholder'
+            },
+            attributes: {
+                remove: ['style','class']
             }
         },
         cache = {
@@ -280,7 +283,7 @@
                      * Deletes invalid nodes
                      * Removes Attributes
                      */
-                    var attsToRemove = ['style','class'],
+                    var attsToRemove = settings.attributes.remove,
                         only = (settings.tags.outerLevel).concat([settings.tags.paragraph]),
                         children = settings.element.children,
                         i, j, k;


### PR DESCRIPTION
I'm integrating Medium in a custom WYSIWYG editor control which uses style for text alignment. With the current setup, the clean method removes desired alignment upon editing. This update allows the user to modify which attributes are to be removed.
