### PR TITLE
Fix for shifting content to a new line on enter.

### DIFF
--- a/medium.js
+++ b/medium.js
@@ -341,7 +341,7 @@
                     
                     // Extract the any text that may need to be included in the newEl
                     if( afterElement ) {
-                        elText = afterElement.innerText;
+                        elText = afterElement.textContent || afterElement.text;
                         cursorPosition = utils.cursor.get();
                         start = cursorPosition.start;
                         end = cursorPosition.end;
@@ -476,7 +476,7 @@
                 }
             },
             enterKey: function (e) {
-            
+                console.log('enter key')
                 if( settings.mode === "inline" ){
                     return utils.preventDefaultEvent(e);
                 }


### PR DESCRIPTION
When a user hits enter while the cursor is in the middle of a line, then text after the cursor is moved down a line. EG, the text is extracted from the focused element, and placed inside the new element created by the user.
