### PR TITLE
add support for setting custom modifiers in the options

### DIFF
--- a/medium.js
+++ b/medium.js
@@ -443,7 +443,15 @@
                             return;
                         }
 
-                        intercept.command[cmd].call(null, e);
+                        var cmdType = typeof cmd;
+                        var fn = null;
+                        if (cmdType === "function") {
+                            fn = cmd;
+                        } else {
+                            fn = intercept.command[cmd];
+                        }
+
+                        fn.call(null, e);
                     }
                 });
 


### PR DESCRIPTION
commands can now be functions as well as strings, like so:

```
new Medium({
        element: document.querySelector('article.content section.editable'),
        autofocus: true,
        placeholder: 'Write some text.'
        modifiers: {
            188: function() { /* do something here */ }
        }
    })
```

(cherry picked from commit 2f38e361fe1d7f01845097909b0b5cc1e2fa3464)
