### PR TITLE
Update index.html to refer to MediumEditor instead of ZenPen

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -120,7 +120,7 @@
                 <p>Medium.js overrides many default keyboard events and substitutes a more cross-browser compliant way to interact with <code>contenteditable</code> elements. This means that you can use <code>contenteditable</code> without fearing your user is going to enter poor or invalid HTML. It keeps things tight, organized, and semantic.</p>
                 
                 <h4>Does this give me the cool highlighting toolbar like Medium's editor</h4>
-                <p><b>No</b>, it does not. If you're looking for a script that adds support for Medium's toolbar, take a look at <a href="https://github.com/daviferreira/medium-editor" target="_blank">MediumEditor</a></p>
+                <p><b>No</b>, it does not. If you're looking for a script that adds support for Medium's toolbar, take a look at <a href="https://github.com/daviferreira/medium-editor" target="_blank">MediumEditor</a>. If you're looking for a complete web based editor with a Medium-like toolbar, take a look at <a href="http://wikiLingoDoesThat.com/">wikiLingo</a>, or <a href="http://zenpen.io/" target="_blank">ZenPen.io</a</p>
                 
                 <h4>There are weird style issues when inserting empty tags. What gives?</h4>
                 <p>Empty tags do not have what is called <code>layout</code>, a sort of property of an element. You need to set a <code>min-height</code> on the paragraph element you specify. </p>


### PR DESCRIPTION
MediumEditor is designed to be general purpose, wheras ZenPen is written with a specific use-case in mind, leaving extracting the relevant code as an exercise for the reader.
