### PR TITLE
Prevent Rich Content Editing via Modifier Key Shortcuts in Non-Rich Mode

### DIFF
--- a/medium.js
+++ b/medium.js
@@ -435,7 +435,7 @@
                     if( cache.cmd ){
 
                         if( ( (settings.mode === "inline") || (settings.mode === "partial") ) && cmd !== "paste" ){
-                            e.preventDefault();
+                            utils.preventDefaultEvent(e);
                             return;
                         }
 


### PR DESCRIPTION
As discussed in Issue #43.

Command/Control+B/I/U still works despite Medium being in inline or partial modes. This minor fix prevents this by preventing the use of these shortcuts on the editor when it is in a non-rich mode.
