### PR TITLE
Fix an issue with and improve performance of getElementsByClassName

### DIFF
--- a/medium.js
+++ b/medium.js
@@ -447,7 +447,7 @@
                 });
 
                 if( settings.maxLength !== -1 ){
-                    var ph = settings.element.getElementsByClassName(settings.cssClasses.placeholder)[0],
+                    var ph = utils.getElementsByClassName(settings.cssClasses.placeholder, settings.element)[0],
                         len = utils.html.text().length;
 
                     if(settings.placeholder && ph){


### PR DESCRIPTION
There was a place in medium in which the `getElementsByClassName` was used in place of `utils.getElementsByCassName`. This will fail on UAs without this function (IE <= 8). I updated this to use the utils convenience function.

I also updated this function so that it tries to use the native (faster) `getElementsByClassName` first (if it exists), before falling back to the polyfill.
