### PR TITLE
Placeholder setClean function

### DIFF
--- a/medium.js
+++ b/medium.js
@@ -754,7 +754,16 @@
 					}
 					d.execCommand(this.tagName, false);
 				}
-			}
+			},
+
+	            	/**
+	             	*
+	             	* @param {Boolean} clean
+	             	* @returns {Medium.Element}
+	             	*/
+	            	setClean: function(clean) {
+	                	throw 'This operation requires that you include "rangy" and "undo".';
+	            	}
 		};
 
 		Medium.Injector.prototype = {


### PR DESCRIPTION
When running in wild mode, triggers on `setClean()` will throw an error (since it's `undefined`). This placeholder functions throws, and provides a much clear error and how to correct the issue.
