### PR TITLE
Add support for a rich text inline mode

### DIFF
--- a/medium.js
+++ b/medium.js
@@ -257,7 +257,7 @@ var Medium = (function(w, d){
                         }
                     },
                     enterKey: function (e) {
-                        if( settings.mode === "inline" ){
+                        if( settings.mode === "inline" || settings.mode === Medium.inlineRichMode ){
                             return utils.preventDefaultEvent(e);
                         }
 
@@ -1097,6 +1097,7 @@ var Medium = (function(w, d){
             if (
                 children.length > 0
                     || this.settings.mode === Medium.inlineMode
+                    || this.settings.mode === Medium.inlineRichMode
                 ) {
                 return;
             }
@@ -1316,7 +1317,7 @@ var Medium = (function(w, d){
                     style.minHeight = el.clientHeight + 'px';
                     style.minWidth = el.clientWidth + 'px';
 
-                    if ( s.mode !== Medium.inlineMode ) {
+                    if ( s.mode !== Medium.inlineMode && s.mode !== Medium.inlineRichMode ) {
                         utils.setupContents();
 
                         if (childCount === 0) {
@@ -1346,6 +1347,10 @@ var Medium = (function(w, d){
                 i,
                 j,
                 k;
+
+            if (s.mode === Medium.inlineRichMode) {
+                only = s.tags.innerLevel;
+            }
 
             // Go through top level children
             for(i=0; i<children.length; i++){
@@ -1533,6 +1538,7 @@ var Medium = (function(w, d){
 	Medium.inlineMode = 'inline';
 	Medium.partialMode = 'partial';
 	Medium.richMode = 'rich';
+    Medium.inlineRichMode = 'inlineRich';
 
     return Medium;
 }).call(this, window, document);


### PR DESCRIPTION
I have added an additional mode which is a blend of inline and rich text models.

It allows you to format text with bold, italics, and other inline elements.

It does not allow you to insert block-level elements such as paragraphs.
