### PR TITLE
Fixes removeChild() on placeholder not in the DOM

### DIFF
--- a/medium.js
+++ b/medium.js
@@ -594,7 +594,7 @@ var Medium = (function (w, d) {
                 settings = this.settings,
                 placeholder = this.placeholder || null;
 
-            if (placeholder !== null) {
+            if (placeholder !== null && placeholder.setup) {
                 //remove placeholder
                 placeholder.parentNode.removeChild(placeholder);
             }


### PR DESCRIPTION
If the Medium instance already has content when created, the placeholder will not be in the DOM and so cannot be removed. Causes the following error:

![screenshot 2014-08-07 12 05 59](https://cloud.githubusercontent.com/assets/319152/3847483/54fa3a3e-1e66-11e4-9d1b-c9fcab575638.png)
