### PR TITLE
Fixes destruction of placeholder

### DIFF
--- a/medium.js
+++ b/medium.js
@@ -594,9 +594,10 @@ var Medium = (function (w, d) {
                 settings = this.settings,
                 placeholder = this.placeholder || null;
 
-            if (placeholder !== null) {
+            if (placeholder !== null && placeholder.setup) {
                 //remove placeholder
                 placeholder.parentNode.removeChild(placeholder);
+                delete el.placeHolderActive;
             }
 
             //remove contenteditable


### PR DESCRIPTION
Fixes a TypeError when trying to remove non-activated placeholder. Also removes a property added to the main element when the placeholder is created (so that it can be properly re-created on the same element).
