### PR TITLE
Add option for handling backspace/delete

### DIFF
--- a/medium.js
+++ b/medium.js
@@ -318,6 +318,14 @@ var Medium = (function (w, d) {
                         return true;
                     },
                     backspaceOrDeleteKey: function (e) {
+                        if (settings.onBackspaceOrDelete !== undefined) {
+                            var result = settings.onBackspaceOrDelete.call(medium, e, el);
+
+                            if (result) {
+                                return;
+                            }
+                        }
+
                         if (el.lastChild === null) return;
 
                         var lastChild = el.lastChild,


### PR DESCRIPTION
This commit adds a setting which enables custom behavior when users hit backspace or delete. If the function returns a truthy value, no subsequent behavior will be run by Medium.js. Otherwise, the function can be used for auxiliary functionality.

The setting is activated by putting a function "onBackspaceOrDelete" on the settings object.
