### PR TITLE
Update index.html -- fix typo in link to Medium.com

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -56,7 +56,7 @@
             </div>
 
             <h4>Inspired</h4>
-            <p>This script is inspired by <a href="http://mediFum.com" target="_blank">Medium's</a> beautiful content editor, something we have aspired to emulate since it's inception.</p>
+            <p>This script is inspired by <a href="http://medium.com" target="_blank">Medium's</a> beautiful content editor, something we have aspired to emulate since it's inception.</p>
 
             <h4>Authors</h4>
             <p>This code is brought to you by:</p>


### PR DESCRIPTION
In **Inspired** section's link to Medium, change href from mediFum.com to medium.com.
